### PR TITLE
Remove node template vars, use hard coded values

### DIFF
--- a/templates/default/.github/workflows/testPublish.yml
+++ b/templates/default/.github/workflows/testPublish.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ [abstractNodeVersion], [abstractNodeVersionNext] ]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: [abstractNodeVersionNext]
+          node-version: 20.x
       - run: npm ci
       - run: npm run build:release
       - uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
When copy-pasting the original templates, we missed a couple of specific template vars. This commit hard codes 18.x and 20.x instead of dealing with variables.

## Summary by Sourcery

CI:
- Replace template variables with hard-coded Node.js versions 18.x and 20.x in GitHub Actions workflow.