### PR TITLE
refactor: update the node version defined for testing #6

### DIFF
--- a/templates/default/.github/settings.yml
+++ b/templates/default/.github/settings.yml
@@ -70,7 +70,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (18.x)", "test (20.x)", "license/cla"]
+        contexts: ["test (20.x)", "test (22.x)", "license/cla"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/templates/default/.github/workflows/testPublish.yml
+++ b/templates/default/.github/workflows/testPublish.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm ci
       - run: npm run build:release
       - uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
Update all node references of 18 and 20 to 20 to 22.

## Summary by Sourcery

Update Node.js versions used for testing and publishing from 18 and 20 to 20 and 22.

CI:
- Update the Node.js versions used in the test and publish workflow to 20.x and 22.x.

Tests:
- Update the required status checks to reflect the new Node.js versions.